### PR TITLE
Add total followers to streamers and add sorting on total followers

### DIFF
--- a/app/Enums/StreamerStatus.php
+++ b/app/Enums/StreamerStatus.php
@@ -6,7 +6,7 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 
-enum StreamerStatus: string implements HasColor, HasLabel, HasIcon
+enum StreamerStatus: string implements HasColor, HasIcon, HasLabel
 {
     case PendingApproval = 'pending_approval';
     case Rejected = 'rejected';
@@ -35,7 +35,7 @@ enum StreamerStatus: string implements HasColor, HasLabel, HasIcon
             self::Approved => 'success',
         };
     }
-    
+
     /**
      * Get the icon for the enum value.
      */
@@ -47,5 +47,4 @@ enum StreamerStatus: string implements HasColor, HasLabel, HasIcon
             self::Approved => 'heroicon-o-check-circle',
         };
     }
-    
 }

--- a/app/Livewire/Home/Streamers.php
+++ b/app/Livewire/Home/Streamers.php
@@ -32,9 +32,10 @@ class Streamers extends Component implements HasActions, HasForms, HasTable
         return $table
             ->poll('10s')
             ->paginationPageOptions([12, 24, 48, 'all'])
-            ->defaultSort(fn (Builder $query, string $direction) => $query
-                ->orderBy('is_live', 'desc')
-                ->orderBy('name', 'asc')
+            ->defaultSort(
+                fn (Builder $query, string $direction) => $query
+                    ->orderBy('is_live', 'desc')
+                    ->orderBy('name', 'asc')
             )
             ->query(
                 Streamer::query()
@@ -54,6 +55,12 @@ class Streamers extends Component implements HasActions, HasForms, HasTable
                                     ->weight('bold'),
                                 Tables\Columns\TextColumn::make('twitch_username')
                                     ->label(__('Twitch Username'))
+                                    ->searchable()
+                                    ->sortable()
+                                    ->color('gray'),
+                                Tables\Columns\TextColumn::make('total_followers')
+                                    ->label(__('Total Followers'))
+                                    ->formatStateUsing(fn ($state) => "Total Followers: $state")
                                     ->searchable()
                                     ->sortable()
                                     ->color('gray'),

--- a/database/migrations/2025_02_17_205218_add_total_followers_to_streamer.php
+++ b/database/migrations/2025_02_17_205218_add_total_followers_to_streamer.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('streamers', function (Blueprint $table) {
+            $table->integer('total_followers')->after('is_live')->default(0);
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -13,10 +13,13 @@ Artisan::command('sync:streamers', function () {
                 $streamer->twitch_username
             );
 
+            $streamerTotalFollowers = Http::get('https://twitchtracker.com/api/channels/summary/'.$streamer->twitch_username)->json('followers_total');
+
             $html = Http::get($url)->body();
 
             $streamer->update([
                 'is_live' => str($html)->contains('"isLiveBroadcast":true'),
+                'total_followers' => $streamerTotalFollowers ?? 0,
             ]);
         });
 })->everyFiveMinutes();


### PR DESCRIPTION
# 🚀 Pull Request

## 💡 Summary
This PR adds the possibility to sort the streamers on the total followers the have. This uses an api call that is free so when the steamers are synced the new field on the streamers model is filled.


## 🎯 Goals
Add more value on sorting the streamers, but can also be used the identify the more popular streamers, but can also be used to boost the less popular streamers.


## 🔍 Changes Overview
Added migration so the total_followers field is added to the streamers model.
Added new api call to an free api so that the total_followers field is filled. If there are no followers found set it default to 0.
Added the sorting method to guest.


## 📝 Change Type

- [x] ✨ New Feature


## 🚧 Known Issues / Limitations
Knowing the api call could be temporally until the maintainer would use the official twitch api.

